### PR TITLE
Fix django < 1.5 smart_text import

### DIFF
--- a/dbarray/fields.py
+++ b/dbarray/fields.py
@@ -2,7 +2,10 @@ import sys
 
 from django.core.exceptions import FieldError, ValidationError
 from django.db import models
-from django.utils.encoding import smart_text
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    from django.utils.encoding import smart_unicode as smart_text
 from collections import deque
 
 PY2 = sys.version_info[0] == 2


### PR DESCRIPTION
Sorry, looks like I overlooked this in 899b3092ffc696981d66da986883bc407b6e3d89.

Thanks to @shultais for [the report](https://github.com/ecometrica/django-dbarray/commit/899b3092ffc696981d66da986883bc407b6e3d89#commitcomment-5150241).
